### PR TITLE
led handling

### DIFF
--- a/src/cfgfile.c
+++ b/src/cfgfile.c
@@ -42,7 +42,7 @@ void default_cfg(struct cfg *cfg)
 		cfg->dead_threshold[i] = 2;
 	}
 
-	cfg->led = 1;
+	cfg->led = 2;
 	cfg->grab_device = 1;
 
 	for(i=0; i<6; i++) {
@@ -268,7 +268,9 @@ int read_cfg(const char *fname, struct cfg *cfg)
 			if(isint) {
 				cfg->led = ival;
 			} else {
-				if(strcmp(val_str, "true") == 0 || strcmp(val_str, "on") == 0 || strcmp(val_str, "yes") == 0) {
+				if(strcmp(val_str, "auto") == 0) {
+					cfg->led = 2;
+				} else if(strcmp(val_str, "true") == 0 || strcmp(val_str, "on") == 0 || strcmp(val_str, "yes") == 0) {
 					cfg->led = 1;
 				} else if(strcmp(val_str, "false") == 0 || strcmp(val_str, "off") == 0 || strcmp(val_str, "no") == 0) {
 					cfg->led = 0;
@@ -427,9 +429,11 @@ int write_cfg(const char *fname, struct cfg *cfg)
 		fputc('\n', fp);
 	}
 
-	if(!cfg->led) {
-		fprintf(fp, "# disable led\n");
-		fprintf(fp, "led = 0\n\n");
+	fprintf(fp, "# led status: on, off, or auto (enabling on connected clients)\n");
+	switch(cfg->led) {
+	case 0: fprintf(fp, "led = off\n\n"); break;
+	case 2: fprintf(fp, "led = auto\n\n"); break;
+	default: fprintf(fp, "led = on\n\n"); break;
 	}
 
 	if(!cfg->grab_device) {

--- a/src/client.c
+++ b/src/client.c
@@ -20,6 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdio.h>
 #include <stdlib.h>
 #include "client.h"
+#include "dev.h"
+#include "spnavd.h"
 
 #ifdef USE_X11
 #include <X11/Xlib.h>
@@ -79,6 +81,8 @@ struct client *add_client(int type, void *cdata)
 
 	if(client_list == NULL) {
 		client->next = NULL;
+		if(cfg.led == 2)
+			set_devices_led(1); /* on first client, turn on led */
 		return (client_list = client);
 	}
 	client->next = client_list;
@@ -96,8 +100,11 @@ void remove_client(struct client *client)
 	if(iter == client) {
 		client_list = iter->next;
 		free(iter);
-		if((iter = client_list) == NULL)
+		if((iter = client_list) == NULL) {
+			if (cfg.led == 2)
+				set_devices_led(0); /* no more clients, turn off led */
 			return;
+		}
 	}
 
 	while(iter->next) {

--- a/src/dev.c
+++ b/src/dev.c
@@ -183,6 +183,15 @@ void set_device_led(struct device *dev, int state)
 	}
 }
 
+void set_devices_led(int state)
+{
+	struct device *dev = get_devices();
+	while(dev) {
+		set_device_led(dev, state);
+		dev = dev->next;
+	}
+}
+
 struct device *get_devices(void)
 {
 	return dev_list;

--- a/src/dev.c
+++ b/src/dev.c
@@ -73,7 +73,7 @@ int init_devices(void)
 			if(open_dev_usb(dev) == -1) {
 				remove_device(dev);
 			} else {
-				printf("using device: %s\n", dev->path);
+				printf("using device: %s (%s)\n", dev->name, dev->path);
 				device_added++;
 				break;
 			}
@@ -83,7 +83,7 @@ int init_devices(void)
 
 	free_usb_devices_list(usblist);
 
-	if(!device_added) {
+	if(!usblist) {
 		fprintf(stderr, "failed to find any supported devices\n");
 		return -1;
 	}

--- a/src/dev.h
+++ b/src/dev.h
@@ -51,6 +51,7 @@ int get_device_fd(struct device *dev);
 int get_device_index(struct device *dev);
 int read_device(struct device *dev, struct dev_input *inp);
 void set_device_led(struct device *dev, int state);
+void set_devices_led(int state);
 
 struct device *get_devices(void);
 

--- a/src/dev_usb_linux.c
+++ b/src/dev_usb_linux.c
@@ -34,6 +34,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "spnavd.h"
 #include "event.h"
 #include "hotplug.h"
+#include "client.h"
 
 #define DEF_MINVAL	(-500)
 #define DEF_MAXVAL	500
@@ -144,7 +145,7 @@ int open_dev_usb(struct device *dev)
 	/* set non-blocking */
 	fcntl(dev->fd, F_SETFL, fcntl(dev->fd, F_GETFL) | O_NONBLOCK);
 
-	if(cfg.led) {
+	if(cfg.led == 1 || (cfg.led == 2 && first_client())) {
 		set_led_evdev(dev, 1);
 	}
 


### PR DESCRIPTION
This PR provides two improvements:
- auto-enabling the LED with connected clients (on if any client is connected, off otherwise)
- provide device name when connected
- print err msg "failed to find any supported devices" only if that's really the case
  Currently it's also printed if no _new_ device is found.