### PR TITLE
Use pkg-config for X11 and Xi

### DIFF
--- a/configure
+++ b/configure
@@ -140,9 +140,9 @@ if [ "$OPT" = 'yes' ]; then
 fi
 
 if [ "$X11" = 'yes' ]; then
-	echo 'xlib = -L/usr/X11/lib -lX11' >>Makefile
-	if [ -n "`check_header X11/extensions/XInput2.h 2>&1`" ]; then
-		echo 'xlib += -lXi' >>Makefile
+	echo "xlib = $(pkg-config --libs --cflags x11)" >>Makefile
+	if $(pkg-config --exists xi); then
+		echo "xlib += $(pkg-config --libs --cflags xi)" >>Makefile
 	fi
 fi
 


### PR DESCRIPTION
The location for X11 libraries was hard coded to /usr/X11/lib, which may
be incorrect for some 64-bit installations (which use /usr/X11/lib64).
Use pkg-config instead of hardcoding library path.

Also use pkg-config for Xi.