### PR TITLE
Point spacenavd.service at new binary location

### DIFF
--- a/contrib/systemd/spacenavd.service
+++ b/contrib/systemd/spacenavd.service
@@ -5,7 +5,7 @@ After=syslog.target
 [Service]
 Type=forking
 PIDFile=/var/run/spnavd.pid
-ExecStart=/usr/bin/spacenavd
+ExecStart=/usr/local/bin/spacenavd
 StandardError=syslog
 
 [Install]


### PR DESCRIPTION
The `spacenavd` binary's install location seems to've changed since `contrib/systemd/spacenavd.service` was contributed.