### PR TITLE
Turn off LED on startup if LED_OFF is set.

### DIFF
--- a/src/dev_usb_linux.c
+++ b/src/dev_usb_linux.c
@@ -178,8 +178,12 @@ int open_dev_usb(struct device *dev)
 	/* set non-blocking */
 	fcntl(dev->fd, F_SETFL, fcntl(dev->fd, F_GETFL) | O_NONBLOCK);
 
-	if(cfg.led == 1 || (cfg.led == 2 && first_client())) {
+	if(cfg.led == LED_ON || (cfg.led == LED_AUTO && first_client())) {
 		set_led_evdev(dev, 1);
+	} else {
+		/* required on some devices to turn off led after plugging in */
+		set_led_evdev(dev, 1);
+		set_led_evdev(dev, 0);
 	}
 
 	/* fill the device function pointers */


### PR DESCRIPTION
When plugging in a SpaceMouse Compact, the LED turns on even if it is disabled in the configuration file.  It only turns off after toggling the LED setting in spnavcfg.

This PR sends a command to disable the LED after connection (if the LED is disabled in the configuration file).  Weirdly enough, a single `set_led_evdev(dev, 0)` call is not enough to turn off the LED (at least on my device).  It is necessary to call `set_led_evdev(dev, 1)` first.