### PR TITLE
Use XTestFakeKeyEvent to send keys

### DIFF
--- a/configure
+++ b/configure
@@ -146,7 +146,7 @@ if [ "$OPT" = 'yes' ]; then
 fi
 
 if [ "$X11" = 'yes' ]; then
-	echo 'xlib = -L/usr/X11/lib -lX11 -lXtst -lm' >>Makefile
+	echo 'xlib = -L/usr/X11/lib -lX11 -lXtst' >>Makefile
 	if [ -n "`check_header X11/extensions/XInput2.h 2>&1`" ]; then
 		echo 'xlib += -lXi' >>Makefile
 	fi

--- a/configure
+++ b/configure
@@ -146,7 +146,7 @@ if [ "$OPT" = 'yes' ]; then
 fi
 
 if [ "$X11" = 'yes' ]; then
-	echo 'xlib = -L/usr/X11/lib -lX11' >>Makefile
+	echo 'xlib = -L/usr/X11/lib -lX11 -lXtst -lm' >>Makefile
 	if [ -n "`check_header X11/extensions/XInput2.h 2>&1`" ]; then
 		echo 'xlib += -lXi' >>Makefile
 	fi

--- a/src/kbemu.c
+++ b/src/kbemu.c
@@ -19,10 +19,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "config.h"
 
 #ifdef USE_X11
-#include <math.h>  // round.
 #include <stdio.h>
 #include <string.h>
-#include <X11/extensions/XTest.h>  // XTestFakeKeyEvent.
+
+#include <X11/extensions/XTest.h>  /* XTestFakeKeyEvent, XTestQueryExtension. */
+
+#include "logger.h"
+
 #include "kbemu.h"
 
 static Display *dpy;
@@ -39,13 +42,53 @@ KeySym kbemu_keysym(const char *str)
 
 void send_kbevent(KeySym key, int press)
 {
-	if(!dpy) return;
-
+	XEvent xevent;
 	Window win;
 	int rev_state;
-	XGetInputFocus(dpy, &win, &rev_state);
+	int event_base_return;
+	int error_base_return;
+	int major_version_return;
+	int minor_version_return;
+	static Bool xtest_extension_tested = False;
+	static Bool use_xtest_extension;
 
-	XTestFakeKeyEvent(dpy, XKeysymToKeycode(dpy, key), press, 0);
+	if(!dpy) return;
+
+	if(!xtest_extension_tested)
+	{
+		use_xtest_extension = XTestQueryExtension(dpy, &event_base_return, &error_base_return, &major_version_return, &minor_version_return);
+		xtest_extension_tested = True;
+		if (!use_xtest_extension)
+		{
+			logmsg(LOG_DEBUG, "Using XTEST extension\n");
+		}
+		else
+		{
+			logmsg(LOG_WARNING, "No XTEST extension available\n");
+		}
+	}
+
+	if(use_xtest_extension)
+	{
+		XTestFakeKeyEvent(dpy, XKeysymToKeycode(dpy, key), press, 0);
+	}
+	else
+	{
+		XGetInputFocus(dpy, &win, &rev_state);
+
+		xevent.type = press ? KeyPress : KeyRelease;
+		xevent.xkey.display = dpy;
+		xevent.xkey.root = DefaultRootWindow(dpy);
+		xevent.xkey.window = win;
+		xevent.xkey.subwindow = None;
+		xevent.xkey.keycode = XKeysymToKeycode(dpy, key);
+		xevent.xkey.state = 0;
+		xevent.xkey.time = CurrentTime;
+		xevent.xkey.x = xevent.xkey.y = 1;
+		xevent.xkey.x_root = xevent.xkey.y_root = 1;
+
+		XSendEvent(dpy, win, True, press ? KeyPressMask : KeyReleaseMask, &xevent);
+	}
 	XFlush(dpy);
 }
 #endif	/* USE_X11 */

--- a/src/kbemu.c
+++ b/src/kbemu.c
@@ -19,8 +19,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "config.h"
 
 #ifdef USE_X11
+#include <math.h>  // round.
 #include <stdio.h>
 #include <string.h>
+#include <X11/extensions/XTest.h>  // XTestFakeKeyEvent.
 #include "kbemu.h"
 
 static Display *dpy;
@@ -37,26 +39,13 @@ KeySym kbemu_keysym(const char *str)
 
 void send_kbevent(KeySym key, int press)
 {
-	XEvent xevent;
-	Window win;
-	int rev_state;
-
 	if(!dpy) return;
 
+	Window win;
+	int rev_state;
 	XGetInputFocus(dpy, &win, &rev_state);
 
-	xevent.type = press ? KeyPress : KeyRelease;
-	xevent.xkey.display = dpy;
-	xevent.xkey.root = DefaultRootWindow(dpy);
-	xevent.xkey.window = win;
-	xevent.xkey.subwindow = None;
-	xevent.xkey.keycode = XKeysymToKeycode(dpy, key);
-	xevent.xkey.state = 0;
-	xevent.xkey.time = CurrentTime;
-	xevent.xkey.x = xevent.xkey.y = 1;
-	xevent.xkey.x_root = xevent.xkey.y_root = 1;
-
-	XSendEvent(dpy, win, True, press ? KeyPressMask : KeyReleaseMask, &xevent);
+	XTestFakeKeyEvent(dpy, XKeysymToKeycode(dpy, key), press, 0);
 	XFlush(dpy);
 }
 #endif	/* USE_X11 */


### PR DESCRIPTION
Using XTestFakeKeyEvent rather than XSendEvent makes Shift, Control and
Alt working. The Escape key was working also with XSendEvent. Other keys
were not tested.