### PR TITLE
spnavd: open the logfile if verbose and not daemonized

### DIFF
--- a/src/spnavd.c
+++ b/src/spnavd.c
@@ -129,7 +129,10 @@ int main(int argc, char **argv)
 
 	if(become_daemon) {
 		daemonize();
-	}
+	} else
+	if (verbose && logfile)
+		start_logfile(logfile);
+
 	write_pid_file();
 
 	logmsg(LOG_INFO, "Spacenav daemon " VERSION "\n");


### PR DESCRIPTION
When running in the foreground with `-d`, there is no output generated to the logfile specified with `-l`. This patch ensures that logging happens.