### PR TITLE
Fix trivial source comment typos

### DIFF
--- a/doc/example-spnavrc
+++ b/doc/example-spnavrc
@@ -17,7 +17,7 @@
 #sensitivity-translation = 1.0
 #sensitivity-rotation = 1.0
 
-# Separate sensitivity for each roation and translation axis.
+# Separate sensitivity for each rotation and translation axis.
 #
 #sensitivity-translation-x = 1.0
 #sensitivity-translation-y = 1.0

--- a/src/dev_usb_linux.c
+++ b/src/dev_usb_linux.c
@@ -349,7 +349,7 @@ struct usb_dev_info *find_usb_devices(int (*match)(const struct usb_dev_info*))
 				/* break to read from file again */
 				break;
 			}
-			/* set second newline to teminating null */
+			/* set second newline to terminating null */
 			next_section[1] = 0;
 			/* point to start of next section */
 			next_section += 2;


### PR DESCRIPTION
Found via `codespell -q 3 -L mot`