### PR TITLE
Filter motion

### DIFF
--- a/doc/example-spnavrc
+++ b/doc/example-spnavrc
@@ -75,6 +75,8 @@
 # available actions:
 #    none,
 #    sensitivity-up, sensitivity-down, sensitivity-reset
+#    disable-rotation
+#    disable-translation
 #
 #bnact16 = sensitivity-up
 #bnact17 = sensitivity-down

--- a/src/cfgfile.c
+++ b/src/cfgfile.c
@@ -68,6 +68,8 @@ void default_cfg(struct cfg *cfg)
 		cfg->devname[i] = 0;
 		cfg->devid[i][0] = cfg->devid[i][1] = -1;
 	}
+	cfg->disable_translation = 0;
+	cfg->disable_rotation = 0;
 }
 
 #define EXPECT(cond) \
@@ -194,6 +196,14 @@ int read_cfg(const char *fname, struct cfg *cfg)
 		} else if(strcmp(key_str, "sensitivity-rotation-z") == 0) {
 			EXPECT(isfloat);
 			cfg->sens_rot[2] = fval;
+
+		} else if(strcmp(key_str, "disable-rotation") == 0) {
+			EXPECT(isint);
+			cfg->disable_rotation = ival;
+
+		} else if(strcmp(key_str, "disable-translation") == 0) {
+			EXPECT(isint);
+			cfg->disable_translation = ival;
 
 		} else if(strcmp(key_str, "invert-rot") == 0) {
 			if(strchr(val_str, 'x')) {
@@ -380,6 +390,10 @@ int write_cfg(const char *fname, struct cfg *cfg)
 	}
 	fputc('\n', fp);
 
+	fprintf(fp, "disable-rotation = %d\n", cfg->disable_rotation);
+	fprintf(fp, "disable-translation = %d\n", cfg->disable_translation);
+	fputc('\n', fp);
+
 	fprintf(fp, "# dead zone; any motion less than this number, is discarded as noise.\n");
 
 	if(cfg->dead_threshold[0] == cfg->dead_threshold[1] && cfg->dead_threshold[1] == cfg->dead_threshold[2] && cfg->dead_threshold[2] == cfg->dead_threshold[3] && cfg->dead_threshold[3] == cfg->dead_threshold[4] && cfg->dead_threshold[4] == cfg->dead_threshold[5]) {
@@ -495,6 +509,8 @@ static struct {
 	{"sensitivity-up", BNACT_SENS_INC},
 	{"sensitivity-down", BNACT_SENS_DEC},
 	{"sensitivity-reset", BNACT_SENS_RESET},
+	{"disable-rotation", BNACT_DISABLE_ROTATION},
+	{"disable-translation", BNACT_DISABLE_TRANSLATION},
 	{0, 0}
 };
 

--- a/src/cfgfile.h
+++ b/src/cfgfile.h
@@ -37,12 +37,16 @@ enum {
 	BNACT_SENS_RESET,
 	BNACT_SENS_INC,
 	BNACT_SENS_DEC,
+	BNACT_DISABLE_ROTATION,
+	BNACT_DISABLE_TRANSLATION,
 
 	MAX_BNACT
 };
 
 struct cfg {
 	float sensitivity, sens_trans[3], sens_rot[3];
+	int disable_rotation;
+	int disable_translation;
 	int dead_threshold[MAX_AXES];
 	int invert[MAX_AXES];
 	int map_axis[MAX_AXES];


### PR DESCRIPTION
Add new actions on buttons:
- `disable-rotation`
- `disable-translation` 

to enable each motion.

Example setup
```
bnact0 = disable-rotation
bnact1 = disable-translation
```

Added constants to `BTN_PRESS`, `BTN_RELEASE` to apply action only on key release

