### PR TITLE
Handle NULs sent when serial device powers up correctly.

### DIFF
--- a/src/dev_serial.c
+++ b/src/dev_serial.c
@@ -106,9 +106,7 @@ static int read_timeout(int fd, char *buf, int bufsz, long tm_usec);
 static void enqueue_motion(struct sball *sb, int axis, int val);
 static void gen_button_events(struct sball *sb, unsigned int prev);
 
-
 static char *memstr(char *buf, int len, char *str);
-
 
 int open_dev_serial(struct device *dev)
 {
@@ -721,12 +719,13 @@ static void gen_button_events(struct sball *sb, unsigned int prev)
 	}
 }
 
-static char *memstr(char *buf, int len, char *str)  {
+static char *memstr(char *buf, int len, char *str)
+{
 	int i,slen = strlen(str);
 	for (i = 0; i < len - slen; i++) {
-					if(!memcmp(buf + i, str, slen)) {
-							return buf + i;
-					}
+		if(!memcmp(buf + i, str, slen)) {
+			return buf + i;
+		}
 	}
 	return NULL;
 }

--- a/src/dev_serial.c
+++ b/src/dev_serial.c
@@ -107,6 +107,9 @@ static void enqueue_motion(struct sball *sb, int axis, int val);
 static void gen_button_events(struct sball *sb, unsigned int prev);
 
 
+static char *memstr(char *buf, int len, char *str);
+
+
 int open_dev_serial(struct device *dev)
 {
 	int fd, sz;
@@ -147,7 +150,7 @@ int open_dev_serial(struct device *dev)
 
 	write(fd, "\r@RESET\r", 8);
 
-	if((sz = read_timeout(fd, buf, sizeof buf - 1, 2000000)) > 0 && (buf[sz] = 0, strstr(buf, "@1"))) {
+	if((sz = read_timeout(fd, buf, sizeof buf - 1, 2000000)) > 0 && memstr(buf, sz, "@1")) {
 		/* we got a response, so it's a spaceball */
 		make_printable(buf, sz);
 		logmsg(LOG_INFO, "Spaceball detected: %s\n", buf);
@@ -716,4 +719,14 @@ static void gen_button_events(struct sball *sb, unsigned int prev)
 		}
 		bit <<= 1;
 	}
+}
+
+static char *memstr(char *buf, int len, char *str)  {
+	int i,slen = strlen(str);
+	for (i = 0; i < len - slen; i++) {
+					if(!memcmp(buf + i, str, slen)) {
+							return buf + i;
+					}
+	}
+	return NULL;
 }

--- a/src/dev_serial.c
+++ b/src/dev_serial.c
@@ -1,6 +1,6 @@
 /*
 spacenavd - a free software replacement driver for 6dof space-mice.
-Copyright (C) 2007-2021 John Tsiombikas <nuclear@member.fsf.org>
+Copyright (C) 2007-2023 John Tsiombikas <nuclear@member.fsf.org>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -106,7 +106,8 @@ static int read_timeout(int fd, char *buf, int bufsz, long tm_usec);
 static void enqueue_motion(struct sball *sb, int axis, int val);
 static void gen_button_events(struct sball *sb, unsigned int prev);
 
-static char *memstr(char *buf, int len, char *str);
+static char *memstr(char *buf, int len, const char *str);
+
 
 int open_dev_serial(struct device *dev)
 {
@@ -719,13 +720,13 @@ static void gen_button_events(struct sball *sb, unsigned int prev)
 	}
 }
 
-static char *memstr(char *buf, int len, char *str)
+static char *memstr(char *buf, int len, const char *str)
 {
-	int i,slen = strlen(str);
-	for (i = 0; i < len - slen; i++) {
-		if(!memcmp(buf + i, str, slen)) {
+	int i, slen = strlen(str);
+	for(i=0; i<len - slen; i++) {
+		if(memcmp(buf + i, str, slen) == 0) {
 			return buf + i;
 		}
 	}
-	return NULL;
+	return 0;
 }


### PR DESCRIPTION
The serial IBM spaceball 4000FLX may produce serial data before the @RESET\r that contains nuls causing the strstr check to end early so the device is not detected.