### PR TITLE
Ignore CadMouse Compact

### DIFF
--- a/src/dev.c
+++ b/src/dev.c
@@ -90,6 +90,7 @@ static struct usbdb_entry {
 static int devid_blacklist[][2] = {
 	{0x256f, 0xc650},	/* cadmouse */
 	{0x256f, 0xc651},	/* cadmouse wireless */
+	{0x256f, 0xc655},	/* CadMouse Compact */
 	{0x256f, 0xc62c},	/* lipari(?) */
 	{0x256f, 0xc641},	/* scout(?) */
 


### PR DESCRIPTION
If not ignored by spacenavd my CadMouse Compact (256f:c655) stops working in current Debian Sid. Perhaps other mice (CadMouse Pro *) should be ignored too or perhaps spacenavd extended to work more like 3Dconnexion software for Windows/macOS for these mice.