### PR TITLE
Ignore CadMouse Pro* (untested!)

### DIFF
--- a/src/dev.c
+++ b/src/dev.c
@@ -90,7 +90,10 @@ static struct usbdb_entry {
 static int devid_blacklist[][2] = {
 	{0x256f, 0xc650},	/* cadmouse */
 	{0x256f, 0xc651},	/* cadmouse wireless */
+	{0x256f, 0xc654},	/* CadMouse Pro Wireless */
 	{0x256f, 0xc655},	/* CadMouse Compact */
+	{0x256f, 0xc656},	/* CadMouse Pro */
+	{0x256f, 0xc657},	/* CadMouse Pro Wireless Left */
 	{0x256f, 0xc62c},	/* lipari(?) */
 	{0x256f, 0xc641},	/* scout(?) */
 


### PR DESCRIPTION
I have taken the liberty of adding the rest of the CadMouse Pro listed here: https://3dconnexion.com/cadmouse/
The USB IDs are untested and compiled from usb.ids and https://github.com/guillaumechauvat/cadmousectl