### PR TITLE
Ignore CadMouse Compact Wireless (untested!)

### DIFF
--- a/src/dev.c
+++ b/src/dev.c
@@ -91,6 +91,7 @@ static int devid_blacklist[][2] = {
 	{0x256f, 0xc650},	/* cadmouse */
 	{0x256f, 0xc651},	/* cadmouse wireless */
 	{0x256f, 0xc655},	/* CadMouse Compact */
+	{0x256f, 0xc658},	/* CadMouse Compact Wireless */
 	{0x256f, 0xc62c},	/* lipari(?) */
 	{0x256f, 0xc641},	/* scout(?) */
 


### PR DESCRIPTION
Also added the CadMouse Compact Wireless from https://3dconnexion.com/cadmouse/ Using the complete(?) list at: https://3dconnexion.com/uk/support/faq/how-can-i-check-if-my-usb-3d-mouse-is-recognized-by-windows/