### PR TITLE
Ignore Keyboard Pro/Numpad Pro (untested!)

### DIFF
--- a/src/dev.c
+++ b/src/dev.c
@@ -95,6 +95,8 @@ static int devid_blacklist[][2] = {
 	{0x256f, 0xc656},	/* CadMouse Pro */
 	{0x256f, 0xc657},	/* CadMouse Pro Wireless Left */
 	{0x256f, 0xc658},	/* CadMouse Compact Wireless */
+	{0x256f, 0xc664},	/* Keyboard Pro */
+	{0x256f, 0xc665},	/* Numpad Pro */
 	{0x256f, 0xc62c},	/* lipari(?) */
 	{0x256f, 0xc641},	/* scout(?) */
 


### PR DESCRIPTION
Finishing off with adding Keyboard Pro and Numpad Pro for completeness. See this: https://3dconnexion.com/product/keyboard-pro-with-numpad/

Added from this list (which I think has got all handled IDs listed except c62c, c636, c640, and c641): https://3dconnexion.com/uk/support/faq/how-can-i-check-if-my-usb-3d-mouse-is-recognized-by-windows/